### PR TITLE
Fixed to work with RRDtool 1.6

### DIFF
--- a/cablegraph
+++ b/cablegraph
@@ -262,7 +262,7 @@ for(my $chan = $start; $chan < $channels; $chan++) {
 if(ref($graph->{summaries})) {
   push(@lines,$graph->{summaries}->($start,$channels));
 }
-my(@args) = ("","-s","now-24h","-e","now","-t",$graph->{title},"-v",$graph->{unit});
+my(@args) = ("-","-s","now-24h","-e","now","-t",$graph->{title},"-v",$graph->{unit});
 if($graph->{scale}) {
   push(@args,@{$graph->{scale}});
 }


### PR DESCRIPTION
Commit https://github.com/oetiker/rrdtool-1.x/commit/0bcfa3de0f484a08eb3cbe7b0e1224e42296c784 broke the current code, filename '-' is now required if you want your image on memory. ( See https://oss.oetiker.ch/rrdtool/doc/rrdgraph.en.html )